### PR TITLE
allow periods in identifiers

### DIFF
--- a/lib/src/main/scala/com/github/gchudnov/kprojekt/parser/LiveParser.scala
+++ b/lib/src/main/scala/com/github/gchudnov/kprojekt/parser/LiveParser.scala
@@ -38,7 +38,7 @@ object LiveParser {
   private def next[_: P] = P("-->")
   private def prev[_: P] = P("<--")
 
-  private def identifier[_: P]    = P(CharsWhileIn("0-9a-zA-Z\\-_").!)
+  private def identifier[_: P]    = P(CharsWhileIn("0-9a-zA-Z\\-_.").!)
   private def identifierSeq[_: P] = P(identifier.rep(sep = ("," ~ space)./))
 
   private def storeSeq[_: P] = P("stores:" ~/ "[" ~/ identifierSeq ~ "]")

--- a/lib/src/test/resources/topologies/fan-out.log
+++ b/lib/src/test/resources/topologies/fan-out.log
@@ -1,6 +1,6 @@
 Topologies:
    Sub-topology: 0
-    Source: KSTREAM-SOURCE-0000000000 (topics: [A])
+    Source: KSTREAM-SOURCE-0000000000 (topics: [A, A.B, A-B, A_B])
       --> KSTREAM-MAPVALUES-0000000001, KSTREAM-MAPVALUES-0000000002
     Processor: KSTREAM-MAPVALUES-0000000001 (stores: [])
       --> KSTREAM-SINK-0000000003

--- a/lib/src/test/scala/com/github/gchudnov/kprojekt/parser/ParserSpec.scala
+++ b/lib/src/test/scala/com/github/gchudnov/kprojekt/parser/ParserSpec.scala
@@ -47,6 +47,13 @@ object ParserSpec extends DefaultRunnableSpec {
               )
             )
           ) &&
+          assert(
+            source
+              .asInstanceOf[Source]
+              .topicSet()
+              .asScala
+              .toSet
+          )(equalTo(Set("A", "A.B", "A-B", "A_B"))) &&
           assert(source.predecessors().asScala)(isEmpty) &&
           assert(source.successors().asScala)(hasSize(equalTo(2))) &&
           assert(proc1.predecessors().asScala)(hasSize(equalTo(1))) &&


### PR DESCRIPTION
I tried running this on a topology that uses topics with periods in the names as a sort of namespacing. It failed parsing with `Error: Cannot parse input:  at 82`. I changed the identifier to allow for periods and added an assertion for the parsing of the topic names. This makes the assumption that other uses of identifiers also tolerate periods, which may not be the case. I could add a separate identifier for that case if so.